### PR TITLE
Resize podcast image for having a same size border

### DIFF
--- a/src/styles/components/Emission.css
+++ b/src/styles/components/Emission.css
@@ -21,7 +21,8 @@
 }
 
 .Emission__image {
-
+    width: 100%;
+    height: 100%;
 }
 
 .Emission--featured .Emission__name {


### PR DESCRIPTION
Les dimensions des bordures des podcasts n'étaient pas homogènes (la bordure en bas était plus petite)